### PR TITLE
Remove requires from to_stylus script

### DIFF
--- a/to_stylus.rb
+++ b/to_stylus.rb
@@ -2,8 +2,6 @@
 # Convert SASS/SCSS to Stylus
 # Initial work by Andrey Popp (https://github.com/andreypopp)
 
-require 'rubygems'
-require 'bundler/setup'
 require 'sass'
 
 class ToStylus < Sass::Tree::Visitors::Base


### PR DESCRIPTION
Possible fix for https://github.com/mojotech/sass2stylus/issues/54 (I was getting a different require/load error when running the node converter)
