### PR TITLE
Fix font in editor for Windows (aka users without Monaco)

### DIFF
--- a/front_end/assets/css/_code_block.styl
+++ b/front_end/assets/css/_code_block.styl
@@ -19,7 +19,7 @@
   height 100%
 
 .CodeMirror pre
-  font-family Monaco
+  font-family Monaco, monospace
   font-size 12px
 
 .sass-col, .styl-col


### PR DESCRIPTION
Added a `monospace` backup to the `.CodeMirror pre` styling to account for Windows machines not shipping with Monaco. I was wondering why the editor was in Times New Roman on my laptop!
